### PR TITLE
fix: training load page shows all zeros (#9)

### DIFF
--- a/algorithms/go/algorithms.go
+++ b/algorithms/go/algorithms.go
@@ -326,3 +326,67 @@ func TssForTargetTsb(currentCtl, currentAtl, targetTsb, ctlTau, atlTau float64) 
 
 	return numerator / denominator
 }
+
+// Monotony calculates training monotony from daily TSS values.
+// Monotony = Mean TSS / StdDev TSS
+// High monotony (>2.0) indicates repetitive training which can increase injury risk.
+// Returns 0 if there's no variance (stddev is 0).
+func Monotony(dailyTSS []float64) float64 {
+	n := len(dailyTSS)
+	if n == 0 {
+		return 0
+	}
+
+	// Calculate mean
+	sum := 0.0
+	for _, tss := range dailyTSS {
+		sum += tss
+	}
+	mean := sum / float64(n)
+
+	// Calculate standard deviation
+	sumSqDiff := 0.0
+	for _, tss := range dailyTSS {
+		diff := tss - mean
+		sumSqDiff += diff * diff
+	}
+
+	variance := sumSqDiff / float64(n)
+	if variance <= 0 {
+		return 0 // No variance means infinite monotony, return 0 to indicate undefined
+	}
+
+	stdDev := math.Sqrt(variance)
+	if stdDev == 0 {
+		return 0
+	}
+
+	return mean / stdDev
+}
+
+// DefaultTRIMPWeights are the standard zone weights for TRIMP calculation.
+// Zone 1 = 1, Zone 2 = 2, Zone 3 = 3, Zone 4 = 4, Zone 5 = 5
+var DefaultTRIMPWeights = []float64{1, 2, 3, 4, 5}
+
+// ZoneBasedTRIMP calculates Training Impulse from time spent in each HR zone.
+// zoneSeconds: array of seconds spent in [Z1, Z2, Z3, Z4, Z5]
+// weights: zone multipliers (use DefaultTRIMPWeights if nil)
+// TRIMP = Σ(time_in_zone × zone_weight)
+func ZoneBasedTRIMP(zoneSeconds []int, weights []float64) float64 {
+	if len(zoneSeconds) == 0 {
+		return 0
+	}
+
+	if weights == nil || len(weights) == 0 {
+		weights = DefaultTRIMPWeights
+	}
+
+	trimp := 0.0
+	for i := 0; i < len(zoneSeconds) && i < len(weights); i++ {
+		// Convert seconds to minutes for TRIMP calculation
+		minutes := float64(zoneSeconds[i]) / 60.0
+		trimp += minutes * weights[i]
+	}
+
+	return trimp
+}

--- a/internal/services/stats.go
+++ b/internal/services/stats.go
@@ -214,10 +214,40 @@ type DailyTrainingLoadPoint struct {
 	TSB float64 `json:"tsb"`
 }
 
+// ComputationStats provides diagnostic information about TSS computation.
+type ComputationStats struct {
+	TotalActivities      int  `json:"total_activities"`
+	ActivitiesWithPower  int  `json:"activities_with_power"`
+	ActivitiesWithTSS    int  `json:"activities_with_tss"`
+	CyclingFTPConfigured bool `json:"cycling_ftp_configured"`
+	RunningFTPConfigured bool `json:"running_ftp_configured"`
+	HRZonesConfigured    bool `json:"hr_zones_configured"`
+}
+
+// WeeklyMetrics contains weekly training metrics.
+type WeeklyMetrics struct {
+	RestDays     int     `json:"rest_days"`      // Days with no activity (0-7)
+	Monotony     float64 `json:"monotony"`       // Mean TSS / StdDev TSS
+	WeeklyStrain float64 `json:"weekly_strain"`  // Total TSS last 7 days
+	WeeklyTRIMP  float64 `json:"weekly_trimp"`   // Total TRIMP last 7 days
+}
+
+// PolarizedBreakdown shows training intensity distribution.
+type PolarizedBreakdown struct {
+	LowPercent      float64 `json:"low_percent"`      // Z1+Z2 %
+	ModeratePercent float64 `json:"moderate_percent"` // Z3 %
+	HighPercent     float64 `json:"high_percent"`     // Z4+Z5 %
+	TotalSeconds    int     `json:"total_seconds"`
+	PeriodDays      int     `json:"period_days"` // 30
+}
+
 // TrainingLoadOutput contains training load data.
 type TrainingLoadOutput struct {
-	Series  []DailyTrainingLoadPoint `json:"series"`
-	Summary *DailyTrainingLoadPoint  `json:"summary,omitempty"`
+	Series        []DailyTrainingLoadPoint `json:"series"`
+	Summary       *DailyTrainingLoadPoint  `json:"summary,omitempty"`
+	Stats         *ComputationStats        `json:"stats,omitempty"`
+	WeeklyMetrics *WeeklyMetrics           `json:"weekly_metrics,omitempty"`
+	Polarized     *PolarizedBreakdown      `json:"polarized,omitempty"`
 }
 
 // --- Zone Trend ---
@@ -684,10 +714,151 @@ func (s *StatsService) GetTrainingLoad(ctx context.Context, in GetTrainingLoadIn
 		}
 	}
 
-	return &TrainingLoadOutput{
+	// Get computation stats for diagnostics
+	repoStats, err := s.trainingLoad.GetComputationStats(ctx, in.AthleteID, after, before)
+	if err != nil {
+		return nil, Wrapf(ErrInternal, "failed to get computation stats: %v", err)
+	}
+
+	var statsOut *ComputationStats
+	if repoStats != nil {
+		statsOut = &ComputationStats{
+			TotalActivities:      repoStats.TotalActivities,
+			ActivitiesWithPower:  repoStats.ActivitiesWithPower,
+			ActivitiesWithTSS:    repoStats.ActivitiesWithTSS,
+			CyclingFTPConfigured: repoStats.CyclingFTPConfigured,
+			RunningFTPConfigured: repoStats.RunningFTPConfigured,
+			HRZonesConfigured:    repoStats.HRZonesConfigured,
+		}
+	}
+
+	output := &TrainingLoadOutput{
 		Series:  seriesOut,
 		Summary: summaryOut,
-	}, nil
+		Stats:   statsOut,
+	}
+
+	// Calculate weekly metrics if we have enough data
+	if len(seriesOut) > 0 {
+		output.WeeklyMetrics = s.calculateWeeklyMetrics(seriesOut)
+	}
+
+	// Get polarized breakdown for last 30 days
+	if s.zoneDistribution != nil {
+		output.Polarized = s.getPolarizedBreakdown(ctx, in.AthleteID)
+	}
+
+	return output, nil
+}
+
+// calculateWeeklyMetrics computes rest days, monotony, and strain from the last 7 days.
+func (s *StatsService) calculateWeeklyMetrics(series []DailyTrainingLoadPoint) *WeeklyMetrics {
+	// Get last 7 days of data
+	n := len(series)
+	startIdx := n - 7
+	if startIdx < 0 {
+		startIdx = 0
+	}
+
+	lastWeek := series[startIdx:]
+	if len(lastWeek) == 0 {
+		return nil
+	}
+
+	// Calculate rest days and collect TSS values
+	restDays := 0
+	var dailyTSS []float64
+	totalStrain := 0.0
+
+	for _, p := range lastWeek {
+		if p.TSS == 0 {
+			restDays++
+		}
+		dailyTSS = append(dailyTSS, p.TSS)
+		totalStrain += p.TSS
+	}
+
+	// Calculate monotony (mean / stddev)
+	monotony := 0.0
+	if len(dailyTSS) > 1 {
+		mean := totalStrain / float64(len(dailyTSS))
+		var sumSqDiff float64
+		for _, tss := range dailyTSS {
+			diff := tss - mean
+			sumSqDiff += diff * diff
+		}
+		stdDev := 0.0
+		if len(dailyTSS) > 0 {
+			stdDev = sqrtFloat(sumSqDiff / float64(len(dailyTSS)))
+		}
+		if stdDev > 0 {
+			monotony = mean / stdDev
+		}
+	}
+
+	return &WeeklyMetrics{
+		RestDays:     restDays,
+		Monotony:     roundTo2(monotony),
+		WeeklyStrain: roundTo2(totalStrain),
+		WeeklyTRIMP:  0, // Will be computed when TRIMP data is available
+	}
+}
+
+// getPolarizedBreakdown returns training intensity distribution for the last 30 days.
+func (s *StatsService) getPolarizedBreakdown(ctx context.Context, athleteID int64) *PolarizedBreakdown {
+	// Ensure zone distributions are computed
+	if err := s.zoneDistribution.EnsureComputed(ctx, athleteID); err != nil {
+		return nil
+	}
+
+	// Get aggregated zone distribution for last 30 days
+	data, err := s.zoneDistribution.GetWeeklyDistribution(ctx, athleteID, 5) // ~5 weeks ≈ 30+ days
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+
+	// Sum across all weeks
+	var z1, z2, z3, z4, z5, total int
+	for _, w := range data {
+		z1 += w.SecondsZ1
+		z2 += w.SecondsZ2
+		z3 += w.SecondsZ3
+		z4 += w.SecondsZ4
+		z5 += w.SecondsZ5
+		total += w.Total
+	}
+
+	if total == 0 {
+		return nil
+	}
+
+	low := float64(z1+z2) / float64(total) * 100
+	moderate := float64(z3) / float64(total) * 100
+	high := float64(z4+z5) / float64(total) * 100
+
+	return &PolarizedBreakdown{
+		LowPercent:      roundTo2(low),
+		ModeratePercent: roundTo2(moderate),
+		HighPercent:     roundTo2(high),
+		TotalSeconds:    total,
+		PeriodDays:      30,
+	}
+}
+
+func sqrtFloat(x float64) float64 {
+	if x <= 0 {
+		return 0
+	}
+	// Newton's method for square root
+	z := x / 2
+	for i := 0; i < 10; i++ {
+		z = (z + x/z) / 2
+	}
+	return z
+}
+
+func roundTo2(v float64) float64 {
+	return float64(int(v*100+0.5)) / 100
 }
 
 // GetZoneTrend returns weekly HR zone distribution data.

--- a/internal/storage/training_load.go
+++ b/internal/storage/training_load.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"log/slog"
 	"math"
 	"strings"
 	"time"
@@ -15,6 +16,16 @@ type DailyTrainingLoadPoint struct {
 	CTL float64 `json:"ctl"`
 	ATL float64 `json:"atl"`
 	TSB float64 `json:"tsb"`
+}
+
+// ComputationStats provides diagnostic information about TSS computation.
+type ComputationStats struct {
+	TotalActivities      int  `json:"total_activities"`
+	ActivitiesWithPower  int  `json:"activities_with_power"`
+	ActivitiesWithTSS    int  `json:"activities_with_tss"`
+	CyclingFTPConfigured bool `json:"cycling_ftp_configured"`
+	RunningFTPConfigured bool `json:"running_ftp_configured"`
+	HRZonesConfigured    bool `json:"hr_zones_configured"`
 }
 
 type TrainingLoadRepository struct {
@@ -97,6 +108,12 @@ func (r *TrainingLoadRepository) EnsureComputedForRange(ctx context.Context, ath
 }
 
 func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, athleteID int64, a ActivityForLoad) error {
+	slog.Debug("computing TSS for activity",
+		"activity_id", a.ID,
+		"sport_type", a.SportType,
+		"start_date", a.StartDate.Format("2006-01-02"),
+		"moving_time_s", a.MovingTimeS)
+
 	streams, err := r.streams.GetByActivityID(ctx, a.ID)
 	if err != nil {
 		return err
@@ -117,8 +134,20 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 		}
 	}
 
+	hasPower := len(wattsRaw) > 0
+	hasSpeed := len(speedRaw) > 0
+	hasHR := len(hrRaw) > 0
+	isRun := strings.Contains(a.SportType, "Run")
+
+	slog.Debug("activity stream availability",
+		"activity_id", a.ID,
+		"has_power", hasPower,
+		"has_speed", hasSpeed,
+		"has_hr", hasHR,
+		"is_run", isRun)
+
 	// 1) Cycling: power-based TSS.
-	if len(wattsRaw) > 0 {
+	if hasPower {
 		ftpPoint, err := r.metrics.LatestBefore(ctx, athleteID, "ftp_cycling_watts", a.StartDate.Time)
 		if err != nil {
 			return err
@@ -132,11 +161,19 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 			np := analysis.NormalizedPower(watts)
 			ifactor := analysis.IntensityFactor(np, ftp)
 			tss := analysis.TrainingStressScore(a.MovingTimeS, np, ftp)
+			slog.Debug("computed TSS using cycling power",
+				"activity_id", a.ID,
+				"method", "cycling_power",
+				"ftp", ftp,
+				"np", np,
+				"if", ifactor,
+				"tss", tss)
 			return r.upsertActivity(ctx, athleteID, a, "cycling_power", ftp, np, ifactor, tss)
 		}
+		slog.Debug("skipping activity: has power data but no cycling FTP configured",
+			"activity_id", a.ID,
+			"sport_type", a.SportType)
 	}
-
-	isRun := strings.Contains(a.SportType, "Run")
 
 	// 2) Running: pace/speed-based TSS (threshold speed).
 	// NOTE: This applies the cycling Normalized Power algorithm (30s rolling avg, 4th power)
@@ -144,7 +181,7 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 	// like NGP (Normalized Graded Pace), it provides a reasonable TSS approximation for
 	// comparing training load across activities. Values are not directly comparable to
 	// cycling TSS or TrainingPeaks rTSS.
-	if isRun && len(speedRaw) > 0 {
+	if isRun && hasSpeed {
 		ftpPoint, err := r.metrics.LatestBefore(ctx, athleteID, "ftp_running_mps", a.StartDate.Time)
 		if err != nil {
 			return err
@@ -158,15 +195,25 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 			np := analysis.NormalizedPower(speeds)
 			ifactor := analysis.IntensityFactor(np, ftp)
 			tss := analysis.TrainingStressScore(a.MovingTimeS, np, ftp)
+			slog.Debug("computed TSS using running pace",
+				"activity_id", a.ID,
+				"method", "running_pace",
+				"threshold_speed", ftp,
+				"np", np,
+				"if", ifactor,
+				"tss", tss)
 			return r.upsertActivity(ctx, athleteID, a, "running_pace", ftp, np, ifactor, tss)
 		}
+		slog.Debug("skipping activity: has speed data but no running FTP configured",
+			"activity_id", a.ID,
+			"sport_type", a.SportType)
 	}
 
 	// 3) Running: HR-based TSS (approximate LTHR from HR zone definition).
 	// NOTE: Similar to pace-based TSS, this applies the cycling NP algorithm to heart rate
 	// data with threshold HR as the "FTP" equivalent. This is an approximation that enables
 	// training load tracking when pace/power data isn't available.
-	if isRun && len(hrRaw) > 0 && r.zones != nil {
+	if isRun && hasHR && r.zones != nil {
 		def, cfg, err := r.zones.GetApplicableHR(ctx, athleteID, a.SportType, a.StartDate.Time)
 		if err != nil {
 			return err
@@ -175,6 +222,9 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 			threshold := cfg.Bounds[3]
 			if def != nil && def.Method == "percent_hrmax" {
 				if cfg.HRMax <= 0 {
+					slog.Debug("skipping activity: HR zones use percent_hrmax but HRMax not configured",
+						"activity_id", a.ID,
+						"sport_type", a.SportType)
 					return nil
 				}
 				threshold *= cfg.HRMax
@@ -187,9 +237,30 @@ func (r *TrainingLoadRepository) computeAndUpsertActivity(ctx context.Context, a
 				nhr := analysis.NormalizedPower(hrs)
 				ifactor := analysis.IntensityFactor(nhr, threshold)
 				tss := analysis.TrainingStressScore(a.MovingTimeS, nhr, threshold)
+				slog.Debug("computed TSS using running HR",
+					"activity_id", a.ID,
+					"method", "running_hr",
+					"threshold_hr", threshold,
+					"nhr", nhr,
+					"if", ifactor,
+					"tss", tss)
 				return r.upsertActivity(ctx, athleteID, a, "running_hr", threshold, nhr, ifactor, tss)
 			}
 		}
+		slog.Debug("skipping activity: has HR data but no valid HR zones configured",
+			"activity_id", a.ID,
+			"sport_type", a.SportType)
+	}
+
+	// Log why we couldn't compute TSS for this activity
+	if !hasPower && !hasSpeed && !hasHR {
+		slog.Debug("skipping activity: no power, speed, or HR stream data available",
+			"activity_id", a.ID,
+			"sport_type", a.SportType)
+	} else if !isRun && !hasPower {
+		slog.Debug("skipping activity: non-running activity without power data",
+			"activity_id", a.ID,
+			"sport_type", a.SportType)
 	}
 
 	return nil
@@ -367,4 +438,86 @@ func (r *TrainingLoadRepository) GetActivityTSS(ctx context.Context, athleteID, 
 		return 0, nil
 	}
 	return row.TSS, nil
+}
+
+// GetComputationStats returns diagnostic information about TSS computation status.
+func (r *TrainingLoadRepository) GetComputationStats(ctx context.Context, athleteID int64, after, before *time.Time) (*ComputationStats, error) {
+	stats := &ComputationStats{}
+
+	// Build date filter clause
+	dateClause := ""
+	args := []any{athleteID}
+	if after != nil {
+		dateClause += " AND a.start_date >= ?"
+		args = append(args, SQLiteTime{Time: *after})
+	}
+	if before != nil {
+		dateClause += " AND a.start_date <= ?"
+		args = append(args, SQLiteTime{Time: *before})
+	}
+
+	// Count total activities in range
+	var totalActivities int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM activities a
+		WHERE a.athlete_id = ?`+dateClause, args...).Scan(&totalActivities)
+	if err != nil {
+		return nil, err
+	}
+	stats.TotalActivities = totalActivities
+
+	// Count activities with power streams
+	var withPower int
+	err = r.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT a.id)
+		FROM activities a
+		JOIN activity_streams s ON s.activity_id = a.id
+		WHERE a.athlete_id = ? AND s.stream_type = 'watts'`+dateClause, args...).Scan(&withPower)
+	if err != nil {
+		return nil, err
+	}
+	stats.ActivitiesWithPower = withPower
+
+	// Count activities with computed TSS
+	var withTSS int
+	err = r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM activities a
+		JOIN activity_training_load tl ON tl.activity_id = a.id
+		WHERE a.athlete_id = ? AND tl.tss > 0`+dateClause, args...).Scan(&withTSS)
+	if err != nil {
+		return nil, err
+	}
+	stats.ActivitiesWithTSS = withTSS
+
+	// Check if cycling FTP is configured
+	ftpPoint, err := r.metrics.LatestBefore(ctx, athleteID, "ftp_cycling_watts", time.Now())
+	if err != nil {
+		return nil, err
+	}
+	stats.CyclingFTPConfigured = ftpPoint != nil && ftpPoint.Value > 0
+
+	// Check if running FTP is configured
+	runFtpPoint, err := r.metrics.LatestBefore(ctx, athleteID, "ftp_running_mps", time.Now())
+	if err != nil {
+		return nil, err
+	}
+	stats.RunningFTPConfigured = runFtpPoint != nil && runFtpPoint.Value > 0
+
+	// Check if HR zones are configured
+	if r.zones != nil {
+		// Check for any HR zone definition
+		var zoneCount int
+		err = r.db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM hr_zone_definitions
+			WHERE athlete_id = ?`, athleteID).Scan(&zoneCount)
+		if err != nil {
+			return nil, err
+		}
+		stats.HRZonesConfigured = zoneCount > 0
+	}
+
+	return stats, nil
 }

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number
+  max?: number
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, ...props }, ref) => {
+    const percentage = Math.min(Math.max((value / max) * 100, 0), 100)
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-primary/20', className)}
+        {...props}
+      >
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    )
+  }
+)
+Progress.displayName = 'Progress'
+
+export { Progress }

--- a/web/src/lib/api/stats.ts
+++ b/web/src/lib/api/stats.ts
@@ -17,6 +17,9 @@ export type {
   PowerZonesResponse,
   DistributionSlice,
   WeeklyZoneDistribution,
+  ComputationStats,
+  WeeklyMetrics,
+  PolarizedBreakdown,
 } from '@/lib/wasm/types.gen'
 
 // ============================================================================
@@ -54,6 +57,9 @@ export interface PowerStatsResponse {
 export interface TrainingLoadResponse {
   series: import('@/lib/wasm/types.gen').DailyTrainingLoadPoint[]
   summary?: import('@/lib/wasm/types.gen').DailyTrainingLoadPoint
+  stats?: import('@/lib/wasm/types.gen').ComputationStats
+  weekly_metrics?: import('@/lib/wasm/types.gen').WeeklyMetrics
+  polarized?: import('@/lib/wasm/types.gen').PolarizedBreakdown
 }
 
 // ZoneTrendResponse - zone distribution data over time

--- a/web/src/lib/wasm/types.gen.ts
+++ b/web/src/lib/wasm/types.gen.ts
@@ -2148,6 +2148,16 @@ export interface CalendarMonthSummary {
   challenges_completed: number
 }
 
+/** ComputationStats provides diagnostic information about TSS computation. */
+export interface ComputationStats {
+  total_activities: number
+  activities_with_power: number
+  activities_with_tss: number
+  cycling_ftp_configured: boolean
+  running_ftp_configured: boolean
+  hr_zones_configured: boolean
+}
+
 export interface ComputePowerBestEffortsInput {
   activity_id: number
   athlete_id: number
@@ -2340,6 +2350,15 @@ export interface PeakPowerHistoryPoint {
   watts: number
 }
 
+/** PolarizedBreakdown shows training intensity distribution. */
+export interface PolarizedBreakdown {
+  low_percent: number
+  moderate_percent: number
+  high_percent: number
+  total_seconds: number
+  period_days: number
+}
+
 /** PowerStatsOutput contains power statistics. */
 export interface PowerStatsOutput {
   durations_s: number[]
@@ -2405,6 +2424,17 @@ export interface SportTypeStat {
 export interface TrainingLoadOutput {
   series: DailyTrainingLoadPoint[]
   summary?: DailyTrainingLoadPoint | null
+  stats?: ComputationStats | null
+  weekly_metrics?: WeeklyMetrics | null
+  polarized?: PolarizedBreakdown | null
+}
+
+/** WeeklyMetrics contains weekly training metrics. */
+export interface WeeklyMetrics {
+  rest_days: number
+  monotony: number
+  weekly_strain: number
+  weekly_trimp: number
 }
 
 /** WeeklyStat represents statistics for a single sport type in the current week. */

--- a/web/src/pages/training-load.tsx
+++ b/web/src/pages/training-load.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { AlertTriangle, CheckCircle, Settings, XCircle } from 'lucide-react'
 import { useTrainingLoad } from '@/lib/api'
 import { TrainingLoadChart } from '@/components/charts'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { Progress } from '@/components/ui/progress'
 
 export function TrainingLoadPage() {
   const [after, setAfter] = useState('')
@@ -15,6 +18,13 @@ export function TrainingLoadPage() {
   })
 
   const series = useMemo(() => data?.series ?? [], [data])
+  const stats = data?.stats
+  const weeklyMetrics = data?.weekly_metrics
+  const polarized = data?.polarized
+
+  // Check if FTP is configured
+  const hasFTPConfigured = stats?.cycling_ftp_configured || stats?.running_ftp_configured
+  const hasNoTSS = stats && stats.activities_with_tss === 0
 
   if (error) {
     return (
@@ -36,6 +46,104 @@ export function TrainingLoadPage() {
         </Button>
       </div>
 
+      {/* Configuration Warning Banner */}
+      {stats && !hasFTPConfigured && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>FTP Not Configured</AlertTitle>
+          <AlertDescription className="flex items-center justify-between">
+            <span>
+              Configure your FTP (Functional Threshold Power/Pace) in Settings to enable training
+              load calculations.
+            </span>
+            <Button asChild variant="outline" size="sm" className="ml-4">
+              <Link to="/settings">
+                <Settings className="mr-2 h-4 w-4" />
+                Configure FTP
+              </Link>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* No TSS Warning */}
+      {stats && hasFTPConfigured && hasNoTSS && (
+        <Alert className="mb-6">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>No Training Load Data</AlertTitle>
+          <AlertDescription>
+            No activities with computed TSS in this date range. This could be because:
+            <ul className="mt-2 list-inside list-disc text-sm">
+              <li>Activities don&apos;t have power or heart rate data</li>
+              <li>FTP was configured after the activities were recorded</li>
+              <li>The date range doesn&apos;t include any activities</li>
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Activity Stats Cards */}
+      {stats && (
+        <div className="mb-6 grid gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total Activities</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.total_activities}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>With Power Data</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.activities_with_power}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>With TSS</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.activities_with_tss}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Configuration</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-1 text-sm">
+              <div className="flex items-center gap-2">
+                {stats.cycling_ftp_configured ? (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span>Cycling FTP</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {stats.running_ftp_configured ? (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span>Running FTP</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {stats.hr_zones_configured ? (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span>HR Zones</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Chart */}
       <Card className="mb-6">
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Range</CardTitle>
@@ -60,28 +168,134 @@ export function TrainingLoadPage() {
         </CardContent>
       </Card>
 
+      {/* Current Summary */}
       {data?.summary && (
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="mb-6 grid gap-4 md:grid-cols-3">
           <Card>
-            <CardHeader>
-              <CardTitle className="text-sm text-muted-foreground">CTL</CardTitle>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">CTL (Fitness)</CardTitle>
             </CardHeader>
             <CardContent className="text-2xl font-bold">{data.summary.ctl.toFixed(1)}</CardContent>
           </Card>
           <Card>
-            <CardHeader>
-              <CardTitle className="text-sm text-muted-foreground">ATL</CardTitle>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">ATL (Fatigue)</CardTitle>
             </CardHeader>
             <CardContent className="text-2xl font-bold">{data.summary.atl.toFixed(1)}</CardContent>
           </Card>
           <Card>
-            <CardHeader>
-              <CardTitle className="text-sm text-muted-foreground">TSB</CardTitle>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-muted-foreground">TSB (Form)</CardTitle>
             </CardHeader>
-            <CardContent className="text-2xl font-bold">{data.summary.tsb.toFixed(1)}</CardContent>
+            <CardContent
+              className={`text-2xl font-bold ${
+                data.summary.tsb > 0 ? 'text-green-500' : data.summary.tsb < -10 ? 'text-red-500' : ''
+              }`}
+            >
+              {data.summary.tsb > 0 ? '+' : ''}
+              {data.summary.tsb.toFixed(1)}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Weekly Metrics */}
+      {weeklyMetrics && (
+        <div className="mb-6">
+          <h2 className="mb-4 text-lg font-semibold">Weekly Summary (Last 7 Days)</h2>
+          <div className="grid gap-4 md:grid-cols-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Rest Days</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{weeklyMetrics.rest_days}</div>
+                <p className="text-xs text-muted-foreground">out of 7</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Weekly Strain</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{weeklyMetrics.weekly_strain.toFixed(0)}</div>
+                <p className="text-xs text-muted-foreground">Total TSS</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Monotony</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{weeklyMetrics.monotony.toFixed(2)}</div>
+                <p className="text-xs text-muted-foreground">
+                  {weeklyMetrics.monotony > 2 ? 'High (risk of overtraining)' : 'Normal'}
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Weekly TRIMP</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  {weeklyMetrics.weekly_trimp > 0 ? weeklyMetrics.weekly_trimp.toFixed(0) : '—'}
+                </div>
+                <p className="text-xs text-muted-foreground">Training Impulse</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      )}
+
+      {/* Polarized Training Breakdown */}
+      {polarized && polarized.total_seconds > 0 && (
+        <div className="mb-6">
+          <h2 className="mb-4 text-lg font-semibold">
+            Polarized Training (Last {polarized.period_days} Days)
+          </h2>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="space-y-4">
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-sm">
+                    <span className="text-blue-500">Low Intensity (Z1-Z2)</span>
+                    <span className="font-medium">{polarized.low_percent.toFixed(1)}%</span>
+                  </div>
+                  <Progress value={polarized.low_percent} className="h-3 bg-muted" />
+                </div>
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-sm">
+                    <span className="text-yellow-500">Moderate (Z3)</span>
+                    <span className="font-medium">{polarized.moderate_percent.toFixed(1)}%</span>
+                  </div>
+                  <Progress value={polarized.moderate_percent} className="h-3 bg-muted" />
+                </div>
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-sm">
+                    <span className="text-red-500">High Intensity (Z4-Z5)</span>
+                    <span className="font-medium">{polarized.high_percent.toFixed(1)}%</span>
+                  </div>
+                  <Progress value={polarized.high_percent} className="h-3 bg-muted" />
+                </div>
+              </div>
+              <p className="mt-4 text-xs text-muted-foreground">
+                Polarized training typically aims for 80% low intensity, 0% moderate, and 20% high
+                intensity. {formatDuration(polarized.total_seconds)} of training time analyzed.
+              </p>
+            </CardContent>
           </Card>
         </div>
       )}
     </div>
   )
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`
+  }
+  return `${minutes}m`
 }


### PR DESCRIPTION
## Summary

Fixes #9 - Training Load page displays all zeros because TSS computation silently fails when FTP is not configured.

**Changes:**
- Add debug logging to TSS computation explaining why activities are skipped (missing FTP, missing HR zones, missing stream data)
- Add `ComputationStats` to API response with diagnostic information
- Add `WeeklyMetrics` (rest days, monotony, weekly strain) and `PolarizedBreakdown` to training load output
- Add `Monotony()` and `ZoneBasedTRIMP()` algorithm functions

**UI Improvements:**
- Warning banner when FTP is not configured with link to Settings
- Alert when no activities have computed TSS with troubleshooting tips
- Stats cards showing total activities, with power data, with TSS
- Configuration status indicators (Cycling FTP ✓/✗, Running FTP ✓/✗, HR Zones ✓/✗)
- Weekly Summary section with rest days, strain, and monotony
- Polarized Training breakdown showing Z1-Z2/Z3/Z4-Z5 distribution

## Test plan

- [ ] Open Training Load page without FTP configured → warning banner appears
- [ ] Configure FTP in Settings → banner disappears, TSS values appear
- [ ] Verify stats cards show correct counts for activities
- [ ] Verify Weekly Summary shows rest days, strain, and monotony
- [ ] Verify Polarized Training breakdown shows zone percentages
- [ ] Check debug logs show activity processing details